### PR TITLE
Had errors when following instructions - amended README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ npm install -g generator-hmrcnodeprototype
 With the generator installed it is time to run it. Create a directory on your computer somewhere and cd into it via the terminal. Then run:
 
 ```
-$ yo generator-hmrcnodeprototype
+$ yo hmrcnodeprototype
 ```
 
 ### Optional starting of the application on completion


### PR DESCRIPTION
Had errors when following instructions - amended README to fit what worked for me - i.e. the command shouldn't contain the 'generator-' prefix in the name when running it.
